### PR TITLE
CI: Fix matrix in future-proof.yml

### DIFF
--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -28,10 +28,11 @@ jobs:
         feature-nightly-dropck_eyepatch: ['', '--features nightly-dropck_eyepatch']
         include:
           # Also future-proof against semver breakage from dependencies.
-          - os: ubuntu-latest
-            rust-toolchain: stable
-            cargo-locked: ''
-            feature-nightly-dropck_eyepatch: ''
+          # (But we don't have any dependencies yet, so don't actually run this.)
+          # - os: ubuntu-latest
+          #   rust-toolchain: stable
+          #   cargo-locked: ''
+          #   feature-nightly-dropck_eyepatch: ''
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -28,8 +28,10 @@ jobs:
         feature-nightly-dropck_eyepatch: ['', '--features nightly-dropck_eyepatch']
         include:
           # Also future-proof against semver breakage from dependencies.
-          - rust-toolchain: stable
+          - os: ubuntu-latest
+            rust-toolchain: stable
             cargo-locked: ''
+            feature-nightly-dropck_eyepatch: ''
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The last cron run gives the error:

> `Error when evaluating 'runs-on' for job 'test-no-ui'. .github/workflows/future-proof.yml (Line: 15, Col: 14): Unexpected value ''`

This is because the `include` entry does not have the same `rust-toolchain` as any regular matrix combination, so it creates a new matrix combination which doesn't inherit any variables.
