### PR TITLE
CI: Remove uses of actions-rs actions.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,11 +40,9 @@ jobs:
             cargo-locked: ''
     steps:
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust-toolchain }}
-          override: true
+        run: |
+          rustup toolchain install "${{ matrix.rust-toolchain }}" --profile=minimal
+          rustup override set "${{ matrix.rust-toolchain }}"
 
       - name: Clone repo
         uses: actions/checkout@v2
@@ -54,12 +52,9 @@ jobs:
         run: cargo update -v
 
       - name: Cargo check
-        uses: actions-rs/cargo@v1
         env:
           RUSTC_BOOTSTRAP: 1
-        with:
-          command: check
-          args: ${{ matrix.cargo-locked }} ${{ matrix.feature-nightly-dropck_eyepatch }}
+        run: cargo check ${{ matrix.cargo-locked }} ${{ matrix.feature-nightly-dropck_eyepatch }}
 
   # == BUILD & TEST == #
   build-and-test:
@@ -78,29 +73,20 @@ jobs:
           - stable
     steps:
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          override: true
-          toolchain: ${{ matrix.rust-toolchain }}
+        run: |
+          rustup toolchain install "${{ matrix.rust-toolchain }}"
+          rustup override set "${{ matrix.rust-toolchain }}"
 
       - name: Clone repo
         uses: actions/checkout@v2
 
-      - name: cargo test --lib --tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib --tests
+      - run: cargo test --lib --tests
 
       - name: cargo test --doc
         if: matrix.rust-toolchain == 'stable'
-        uses: actions-rs/cargo@v1
         env:
           RUSTC_BOOTSTRAP: 1
-        with:
-          command: test
-          args: --features better-docs --doc
+        run: cargo test --features better-docs --doc
 
   required-jobs:
     name: 'All the required jobs'

--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -53,4 +53,5 @@ jobs:
           cargo test \
             --features better-docs \
             ${{ matrix.cargo-locked }} \
-            ${{ matrix.feature-nightly-dropck_eyepatch }}
+            ${{ matrix.feature-nightly-dropck_eyepatch }} \
+          ;

--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -35,11 +35,9 @@ jobs:
           #   feature-nightly-dropck_eyepatch: ''
     steps:
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          override: true
-          toolchain: ${{ matrix.rust-toolchain }}
+        run: |
+          rustup toolchain install "${{ matrix.rust-toolchain }}"
+          rustup override set "${{ matrix.rust-toolchain }}"
 
       - name: Clone repo
         uses: actions/checkout@v2
@@ -49,12 +47,10 @@ jobs:
         run: cargo update -v
 
       - name: Cargo test
-        uses: actions-rs/cargo@v1
         env:
           RUSTC_BOOTSTRAP: 1
-        with:
-          command: test
-          args: |
-            --features better-docs
-            ${{ matrix.cargo-locked }}
+        run: |
+          cargo test \
+            --features better-docs \
+            ${{ matrix.cargo-locked }} \
             ${{ matrix.feature-nightly-dropck_eyepatch }}


### PR DESCRIPTION
They are not currently maintained and use deprecated features, resulting in warnings from GitHub like:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

It's easy to replace them, because GitHub hosted runners come with `rustup` already installed. Note that this will lose one piece of functionality: diagnostics displayed inline with GitHub code listings.