### PR TITLE
Rename cfg_match to match_cfg to avoid name conflicts with new macro in nightly std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod manually_drop;
 
 #[rustfmt::skip]
 /// I really don't get the complexity of `cfg_if!`…
-macro_rules! cfg_match {
+macro_rules! match_cfg {
     (
         _ => { $($expansion:tt)* } $(,)?
     ) => (
@@ -23,17 +23,17 @@ macro_rules! cfg_match {
         $($($rest:tt)+)? )?
     ) => (
         #[cfg($cfg)]
-        crate::cfg_match! { _ => $expansion } $($(
+        crate::match_cfg! { _ => $expansion } $($(
 
         #[cfg(not($cfg))]
-        crate::cfg_match! { $($rest)+ } )?)?
+        crate::match_cfg! { $($rest)+ } )?)?
     );
 
-    // Bonus: expression-friendly syntax: `cfg_match!({ … })`
+    // Bonus: expression-friendly syntax: `match_cfg!({ … })`
     ({
         $($input:tt)*
     }) => ({
-        crate::cfg_match! { $($input)* }
+        crate::match_cfg! { $($input)* }
     });
 }
-use cfg_match;
+use match_cfg;

--- a/src/maybe_dangling.rs
+++ b/src/maybe_dangling.rs
@@ -292,7 +292,7 @@ impl<T> MaybeDangling<T> {
 }
 
 // The main difference with `ManuallyDrop`: automatic drop glue!
-crate::cfg_match! {
+crate::match_cfg! {
     feature = "nightly-dropck_eyepatch" => {
         #[allow(unsafe_code)]
         unsafe impl<#[may_dangle] T> Drop for MaybeDangling<T> {


### PR DESCRIPTION
Fixes #8

Inspired by https://github.com/getditto/safer_ffi/pull/191